### PR TITLE
Replace deprecated scipy.signal.hanning

### DIFF
--- a/itsfm/frequency_tracking.py
+++ b/itsfm/frequency_tracking.py
@@ -305,7 +305,7 @@ def pwvd_transform(input_signal, fs, **kwargs):
         https://pypi.org/project/tftb/
     '''
     window_length = kwargs.get('pwvd_window', 0.001)
-    window = kwargs.get('pwvd_window_type', signal.hanning(int(fs*window_length)))
+    window = kwargs.get('pwvd_window_type', np.hanning(int(fs*window_length)))
     analytical = signal.hilbert(input_signal)
     p = PseudoWignerVilleDistribution(analytical, fwindow=window)
     pwvd_output = p.run();

--- a/itsfm/tests/tests.py
+++ b/itsfm/tests/tests.py
@@ -83,7 +83,7 @@ class TestGetFMRegions(unittest.TestCase):
     def test_invalid_and_onefms(self):
         valid_fm = get_fm_regions(self.short_and_longfm, 
                                   fs=1.0, min_fm_duration=3.0)
-        expected = np.bool8(np.concatenate((np.zeros(5),np.ones(3))))
+        expected = np.bool_(np.concatenate((np.zeros(5),np.ones(3))))
         input_and_output_same = np.array_equal(valid_fm, expected)
         self.assertTrue(input_and_output_same)
     


### PR DESCRIPTION
The scipy.signal.hanning function is deprecated and replaced by
scipy.signal.windows.hann in newer versions of scipy,
throwing an error.
This commit replaces the function with numpy.hanning,
which is available in numpy>1.15.