### PR TITLE
Correct reference 'segments' to 'segment_locations'

### DIFF
--- a/itsfm/frequency_tracking.py
+++ b/itsfm/frequency_tracking.py
@@ -198,7 +198,7 @@ def clean_up_spikes(whole_freqeuncy_profile, fs, **kwargs):
     nonzero_freqs, num_regions = ndimage.label(whole_freqeuncy_profile>0)
     segment_locations = ndimage.find_objects(nonzero_freqs)
     
-    if len(segments) <1 : 
+    if len(segment_locations) <1 : 
         raise ValueError('No non-zero frequency sounds found..!')
     
     de_spiked = np.zeros(whole_freqeuncy_profile.size)


### PR DESCRIPTION
The `if` statement now correctly raises an error if the function above
finds no non-zero frequency sounds, by checking `segment_locations`
instead of the undefined variable `segments`.